### PR TITLE
Use only max speed until it gets close

### DIFF
--- a/src/ourdrive_node.cpp
+++ b/src/ourdrive_node.cpp
@@ -34,6 +34,8 @@ int scan_number = 0; // how many times scancallback was called
 const int scan_number_gijoon = 500;
 const int scan_number_decelerate_gijoon = 400;
 
+boolean is_max_speed_okay = true;
+
 double min(double a, double b) {
     return a > b ? b : a;
 }
@@ -232,10 +234,15 @@ public:
 	    
 	// first start algorithm
 	scan_number++;
+	    /*
 if (scan_number > scan_number_decelerate_gijoon){
 	velocity--;
 }
-else if (scan_number > scan_number_gijoon){
+else if (scan_number > scan_number_gijoon){*/
+	if (is_max_speed_okay) {
+		if(scan_msg->ranges[scan_msg->ranges.size()/2] < 20) is_max_speed_okay = false;
+	}
+	else {
         int original_max = maximum_element_index(filtered_ranges);
 
         int max_element_index = -1;


### PR DESCRIPTION
Opted to only use max speed at first, and not later because it might crash into other cars in other areas. However, as I am writing this, I think we could try and make it go back to the original algorithm when it detects something right in front. And then go full speed again when the road is clear.